### PR TITLE
PLAT-179: added boolean forceSync param to refresh() and run()

### DIFF
--- a/oap-logstream/src/main/java/oap/logstream/disk/AbstractFinisher.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/AbstractFinisher.java
@@ -39,9 +39,13 @@ public abstract class AbstractFinisher implements Runnable {
             threads, sourceDirectory, corruptedDirectory, mask, Dates.durationToString( safeInterval ), bufferSize );
     }
 
-    @SneakyThrows
     @Override
-    public void run() {
+    public void run(){
+        run( false );
+    }
+
+    @SneakyThrows
+    public void run( boolean forceSync ) {
         log.debug( "let's start packing of {} in {}", mask, sourceDirectory );
         var timestampStr = timestamp.format( DateTime.now() );
 
@@ -58,7 +62,7 @@ public abstract class AbstractFinisher implements Runnable {
                 if( LogMetadata.isMetadata( path ) ) continue;
 
                 timestamp.parse( path ).ifPresentOrElse( dt -> {
-                    if( dt.isBefore( bucketStartTime ) ) {
+                    if( forceSync || dt.isBefore( bucketStartTime ) ) {
                         pool.execute( () -> process( path, dt ) );
                     } else log.debug( "skipping (current timestamp) {}", path );
                 }, () -> log.error( "what a hell is that {}", path ) );

--- a/oap-logstream/src/main/java/oap/logstream/disk/DiskLoggerBackend.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/DiskLoggerBackend.java
@@ -82,7 +82,7 @@ public class DiskLoggerBackend extends AbstractLoggerBackend {
             writers, Cache::size );
 
         pool = Executors.newScheduledThreadPool( 1, "disk-logger-backend" );
-        pool.scheduleWithFixedDelay( this::refresh, 10, 10, SECONDS );
+        pool.scheduleWithFixedDelay( () -> refresh(false ), 10, 10, SECONDS );
     }
 
     public DiskLoggerBackend( Path logDirectory, Timestamp timestamp, int bufferSize ) {
@@ -126,10 +126,10 @@ public class DiskLoggerBackend extends AbstractLoggerBackend {
         return new AvailabilityReport( enoughSpace ? OPERATIONAL : FAILED );
     }
 
-    public void refresh() {
+    public void refresh( boolean forceSync ) {
         for( var writer : writers.asMap().values() ) {
             try {
-                writer.refresh();
+                writer.refresh( forceSync );
             } catch( Exception e ) {
                 log.error( e.getMessage(), e );
             }

--- a/oap-logstream/src/main/java/oap/logstream/disk/DiskLoggerBackend.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/DiskLoggerBackend.java
@@ -82,7 +82,7 @@ public class DiskLoggerBackend extends AbstractLoggerBackend {
             writers, Cache::size );
 
         pool = Executors.newScheduledThreadPool( 1, "disk-logger-backend" );
-        pool.scheduleWithFixedDelay( () -> refresh(false ), 10, 10, SECONDS );
+        pool.scheduleWithFixedDelay( () -> refresh( false ), 10, 10, SECONDS );
     }
 
     public DiskLoggerBackend( Path logDirectory, Timestamp timestamp, int bufferSize ) {

--- a/oap-logstream/src/main/java/oap/logstream/disk/Writer.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/Writer.java
@@ -108,7 +108,7 @@ public class Writer implements Closeable {
             throw new LoggerException( "writer is already closed!" );
         }
         try {
-            refresh();
+            refresh( false );
             var filename = filename();
             if( out == null )
                 if( !java.nio.file.Files.exists( filename ) ) {
@@ -165,9 +165,9 @@ public class Writer implements Closeable {
         return logDirectory.resolve( lastPattern );
     }
 
-    public synchronized void refresh() {
+    public synchronized void refresh( boolean forceSync ) {
         var currentPattern = currentPattern();
-        if( !Objects.equals( this.lastPattern, currentPattern ) ) {
+        if( forceSync || !Objects.equals( this.lastPattern, currentPattern ) ) {
             currentPattern = currentPattern();
 
             log.trace( "change pattern from '{}' to '{}'", this.lastPattern, currentPattern );


### PR DESCRIPTION
- Added boolean input parameter forceSync to run() in AbstractFinisher
- Added boolean input parameter forceSync to refresh() in DiskLoggerBackend
- Added boolean input parameter forceSync to refresh() in Writer
- if forceSync is TRUE, skip the time check (run code regardless of the time)