### PR TITLE
DSP-3751: tsv and parquet logs must be created together ( fix oap configuration )

### DIFF
--- a/oap-logstream/src/main/java/oap/logstream/disk/DiskLoggerBackend.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/DiskLoggerBackend.java
@@ -89,10 +89,14 @@ public class DiskLoggerBackend extends AbstractLoggerBackend implements Cloneabl
     public int maxVersions = 20;
     private volatile boolean closed;
 
-    public final WriterConfiguration writerConfiguration = new WriterConfiguration();
+    public final WriterConfiguration writerConfiguration;
+
+    public DiskLoggerBackend( Path logDirectory, List<LogFormat> formats, Timestamp timestamp, int bufferSize ) {
+        this( logDirectory, formats, new WriterConfiguration(), timestamp, bufferSize );
+    }
 
     @SuppressWarnings( "unchecked" )
-    public DiskLoggerBackend( Path logDirectory, List<LogFormat> formats, Timestamp timestamp, int bufferSize ) {
+    public DiskLoggerBackend( Path logDirectory, List<LogFormat> formats, WriterConfiguration writerConfiguration, Timestamp timestamp, int bufferSize ) {
         log.info( "logDirectory '{}' formats {} timestamp {} bufferSize {} writerConfiguration {}",
             logDirectory, formats, timestamp, FileUtils.byteCountToDisplaySize( bufferSize ), writerConfiguration );
 
@@ -100,6 +104,7 @@ public class DiskLoggerBackend extends AbstractLoggerBackend implements Cloneabl
 
         this.logDirectory = logDirectory;
         this.formats = formats;
+        this.writerConfiguration = writerConfiguration;
         this.timestamp = timestamp;
         this.bufferSize = bufferSize;
 

--- a/oap-logstream/src/main/java/oap/logstream/disk/ParquetWriter.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/ParquetWriter.java
@@ -98,11 +98,12 @@ public class ParquetWriter extends AbstractWriter<org.apache.parquet.hadoop.Parq
         super( LogFormat.PARQUET, logDirectory, filePattern, logId, bufferSize, timestamp, maxVersions );
         this.configuration = configuration;
 
-        if( !configuration.excludeFieldsIfPropertiesExists.isEmpty() ) {
-            if( Lists.allMatch( configuration.excludeFieldsIfPropertiesExists, logId.properties::containsKey ) ) {
-                excludeFields.addAll( configuration.excludeFieldsIfPropertiesExists );
+
+        configuration.excludeFieldsIfPropertiesExists.forEach( ( field, property ) -> {
+            if( logId.properties.containsKey( property ) ) {
+                excludeFields.add( field );
             }
-        }
+        } );
 
         log.debug( "exclude fields {}", excludeFields );
 

--- a/oap-logstream/src/main/java/oap/logstream/disk/ParquetWriter.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/ParquetWriter.java
@@ -127,8 +127,9 @@ public class ParquetWriter extends AbstractWriter<org.apache.parquet.hadoop.Parq
             messageTypeBuilder.addField( ( Type ) fieldType.named( header ) );
         }
 
-        log.debug( "writer path {} logType {} headers {} filePrefixPattern {} compressionCodecName {} bufferSize {}",
-            currentPattern(), logId.logType, Arrays.asList( logId.headers ), logId.filePrefixPattern, configuration.compressionCodecName, bufferSize
+        log.debug( "writer path '{}' logType '{}' headers {} filePrefixPattern '{}' properties {} compressionCodecName '{}' bufferSize '{}'",
+            currentPattern(), logId.logType, Arrays.asList( logId.headers ), logId.filePrefixPattern,
+            logId.properties, configuration.compressionCodecName, bufferSize
         );
 
         messageType = messageTypeBuilder.named( "logger" );

--- a/oap-logstream/src/main/java/oap/logstream/disk/ParquetWriter.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/ParquetWriter.java
@@ -127,9 +127,9 @@ public class ParquetWriter extends AbstractWriter<org.apache.parquet.hadoop.Parq
             messageTypeBuilder.addField( ( Type ) fieldType.named( header ) );
         }
 
-        log.debug( "writer path '{}' logType '{}' headers {} filePrefixPattern '{}' properties {} compressionCodecName '{}' bufferSize '{}'",
+        log.debug( "writer path '{}' logType '{}' headers {} filePrefixPattern '{}' properties {} configuration '{}' bufferSize '{}'",
             currentPattern(), logId.logType, Arrays.asList( logId.headers ), logId.filePrefixPattern,
-            logId.properties, configuration.compressionCodecName, bufferSize
+            logId.properties, configuration, bufferSize
         );
 
         messageType = messageTypeBuilder.named( "logger" );

--- a/oap-logstream/src/main/java/oap/logstream/disk/WriterConfiguration.java
+++ b/oap-logstream/src/main/java/oap/logstream/disk/WriterConfiguration.java
@@ -28,7 +28,7 @@ import lombok.ToString;
 import oap.util.Dates;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 
 @ToString
 public class WriterConfiguration {
@@ -48,7 +48,7 @@ public class WriterConfiguration {
     @ToString
     public static class ParquetConfiguration {
         public final CompressionCodecName compressionCodecName;
-        public final ArrayList<String> excludeFieldsIfPropertiesExists = new ArrayList<>();
+        public final LinkedHashMap<String, String> excludeFieldsIfPropertiesExists = new LinkedHashMap<>();
 
         public ParquetConfiguration() {
             this( CompressionCodecName.ZSTD );

--- a/oap-logstream/src/test/java/oap/logstream/disk/ParquetWriterTest.java
+++ b/oap-logstream/src/test/java/oap/logstream/disk/ParquetWriterTest.java
@@ -116,10 +116,10 @@ public class ParquetWriterTest extends Fixtures {
             new byte[] { Types.DATETIME.id }
         };
         LogId logId = new LogId( "", "log", "log", 0,
-            Map.of( "p", "1", "COL1", "1" ), headers, types );
+            Map.of( "p", "1", "COL1_property_name", "1" ), headers, types );
         Path logs = TestDirectoryFixture.testPath( "logs" );
         WriterConfiguration.ParquetConfiguration parquetConfiguration = new WriterConfiguration.ParquetConfiguration();
-        parquetConfiguration.excludeFieldsIfPropertiesExists.add( "COL1" );
+        parquetConfiguration.excludeFieldsIfPropertiesExists.put( "COL1", "COL1_property_name" );
         try( var writer = new ParquetWriter( logs, FILE_PATTERN, logId, parquetConfiguration, 1024, BPH_12, 20 ) ) {
             writer.write( CURRENT_PROTOCOL_VERSION, content1, msg -> {} );
         }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </modules>
 
     <properties>
-        <oap-logstream.project.version>18.10.0.2</oap-logstream.project.version>
+        <oap-logstream.project.version>18.10.0.3</oap-logstream.project.version>
 
         <oap.deps.oap.version>18.10.33.1-oap_ds-1731</oap.deps.oap.version>
         <oap.deps.oap.tsv.version>17.4.1.8</oap.deps.oap.tsv.version>


### PR DESCRIPTION
fix:
1. column name and property name may not match
2. oap-kernel did not update the configuration