### PR TITLE
added data into SocketLoggerServer trace logs

### DIFF
--- a/oap-logstream/src/main/java/oap/logstream/net/SocketLoggerServer.java
+++ b/oap-logstream/src/main/java/oap/logstream/net/SocketLoggerServer.java
@@ -37,6 +37,7 @@ import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 
 import static oap.logstream.LogStreamProtocol.MESSAGE_TYPE;
@@ -124,8 +125,9 @@ public class SocketLoggerServer implements MessageListener, Closeable {
         var buffer = new byte[length];
         in.readFully( buffer, 0, length );
 
-        log.trace( "[{}] logging (properties {} filePreffix {} logType {} headers {} types {}, {})",
-            hostName, properties, filePreffix, logType, headers, types, length );
+        log.trace( "[{}] logging (properties {} filePreffix {} logType {} headers {} types {} data {} length {})",
+            hostName, properties, filePreffix, logType, headers, types,
+            "|" + new String( buffer, StandardCharsets.UTF_8 ).replace( "\n", "|" ), length );
 
         backend.log( version, clientHostname, filePreffix, properties, logType, headers, types, buffer, 0, length );
     }


### PR DESCRIPTION
need to see data that has been logged into the files 

format: 1
7:34:23.160 [XNIO-2 task-2] TRACE o.logstream.net.SocketLoggerServer - [localhost] logging (properties {NAME=event} filePreffix /${NAME} logType event1 headers [TIMESTAMP	NAME	VALUE1	VALUE2	VALUE3] types [[1]] data |2021-01-01 01:00:00	event	value1	222	333|2021-01-01 01:00:00	event	value1	222	333| length 82)

@nofateg please review
